### PR TITLE
oscmix: hotplug support — periodic device scan, reconnect, GTK scanning page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ AVAHI_LDLIBS?=$$(pkg-config --libs-only-l avahi-client) -lpthread
 BONJOUR?=$(OS-Darwin)
 BONJOUR_LDLIBS?=-lpthread
 
+USBSCAN_OBJ-$(OS-Linux)= usbscan.o
+
 MDNS_OBJ-$(AVAHI)=   mdns_avahi.o
 MDNS_OBJ-$(BONJOUR)= mdns_bonjour.o
 MDNS_CFLAGS-$(AVAHI)=   $(AVAHI_CFLAGS) -DHAVE_MDNS
@@ -84,6 +86,7 @@ OSCMIX_OBJ=\
 	socket.o\
 	sysex.o\
 	util.o\
+	$(USBSCAN_OBJ-y)\
 	$(MDNS_OBJ-y)\
 	$(DEVICES)
 

--- a/coremidiio.c
+++ b/coremidiio.c
@@ -310,14 +310,16 @@ notify(const struct MIDINotification *n, void *info)
 		obj = ar->child;
 		epname(obj, name, sizeof name);
 		if ((g_mode & READ) && ar->childType == kMIDIObjectType_Source
-				&& ctx[0].ep == 0 && strcmp(name, g_src_name) == 0) {
+				&& ctx[0].ep == 0 && g_src_name[0] != '\0'
+				&& strcmp(name, g_src_name) == 0) {
 			ctx[0].ep = (MIDIEndpointRef)obj;
 			err = MIDIPortConnectSource(ctx[0].port, ctx[0].ep, NULL);
 			if (err)
 				fprintf(stderr, "coremidiio: MIDIPortConnectSource: %d\n", (int)err);
 		}
 		if ((g_mode & WRITE) && ar->childType == kMIDIObjectType_Destination
-				&& ctx[1].ep == 0 && strcmp(name, g_dst_name) == 0) {
+				&& ctx[1].ep == 0 && g_dst_name[0] != '\0'
+				&& strcmp(name, g_dst_name) == 0) {
 			ctx[1].ep = (MIDIEndpointRef)obj;
 		}
 		reader_ok = !(g_mode & READ) || ctx[0].ep != 0;
@@ -370,8 +372,18 @@ main(int argc, char *argv[])
 	int port[2], fd[2];
 	CFStringRef name;
 	int mode;
-	struct context ctx[2];
+	struct context ctx[2] = {0};
 	int ctrl[2];
+
+	/* ctx is passed to MIDIClientCreate as the notify callback's
+	 * info pointer. notify() reads ctx[0].ep and ctx[1].ep before
+	 * initreader()/initwriter() have populated them — if a hotplug
+	 * event fires during that window (or for WRITE-only / READ-only
+	 * modes where only one slot is initialized), uninitialized
+	 * endpoint values would be compared against the incoming object
+	 * and might randomly match, causing a spurious disconnect. Zero
+	 * initialization keeps the early-return path in notify() correct
+	 * until real endpoints are installed. */
 
 	port[0] = -1;
 	port[1] = -1;

--- a/coremidiio.c
+++ b/coremidiio.c
@@ -1,4 +1,5 @@
 #define _DEFAULT_SOURCE
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <CoreFoundation/CoreFoundation.h>
@@ -13,10 +14,17 @@ struct context {
 	int fd;
 };
 
+/* Global state for hotplug reconnect */
+static bool g_connected;     /* true when MIDI endpoints are live */
+static int g_ctrl_wfd = -1;  /* write end of control pipe to oscmix; -1 if no child */
+static int g_mode;           /* READ / WRITE flags at startup */
+static char g_src_name[256]; /* display name of the source endpoint  */
+static char g_dst_name[256]; /* display name of the destination endpoint */
+
 static void
 usage(void)
 {
-	fprintf(stderr, 
+	fprintf(stderr,
 			"usage: coremidiio [-rw] [-f rfd,wfd] [-p port] [cmd...]\n "
 			"       coremidiio [-l] (list ports)\n"
 			"       coremidiio [-n virtPortname]\n"
@@ -94,6 +102,9 @@ midiread(const MIDIPacketList *list, void *info, void *src)
 static OSStatus
 midiwrite(struct context *ctx, MIDIPacketList *list)
 {
+	/* Drop outbound packets while the device is disconnected. */
+	if (!g_connected)
+		return noErr;
 	if (ctx->port)
 		return MIDISend(ctx->port, ctx->ep, list);
 	return MIDIReceived(ctx->ep, list);
@@ -266,14 +277,59 @@ initwriter(struct context *ctx, MIDIClientRef client, CFStringRef name, int inde
 static void
 notify(const struct MIDINotification *n, void *info)
 {
+	MIDIObjectAddRemoveNotification *ar;
 	struct context *ctx;
 	MIDIObjectRef obj;
+	OSStatus err;
+	char name[256];
+	unsigned char sig;
+	bool reader_ok, writer_ok;
 
 	ctx = info;
 	if (n->messageID == kMIDIMsgObjectRemoved) {
-		obj = ((MIDIObjectAddRemoveNotification *)n)->child;
-		if (obj == ctx[0].ep || obj == ctx[1].ep)
-			CFRunLoopStop(CFRunLoopGetMain());
+		ar = (MIDIObjectAddRemoveNotification *)n;
+		obj = ar->child;
+		if (obj != ctx[0].ep && obj != ctx[1].ep)
+			return;
+		if (!g_connected)
+			return;  /* already handling a disconnect */
+		g_connected = false;
+		if ((g_mode & READ) && ctx[0].port && ctx[0].ep) {
+			MIDIPortDisconnectSource(ctx[0].port, ctx[0].ep);
+			ctx[0].ep = 0;
+		}
+		if (g_mode & WRITE)
+			ctx[1].ep = 0;
+		if (g_ctrl_wfd >= 0) {
+			sig = 0x00;
+			write(g_ctrl_wfd, &sig, 1);
+		}
+		fprintf(stderr, "coremidiio: device removed; waiting for reconnect\n");
+	} else if (n->messageID == kMIDIMsgObjectAdded && !g_connected) {
+		ar = (MIDIObjectAddRemoveNotification *)n;
+		obj = ar->child;
+		epname(obj, name, sizeof name);
+		if ((g_mode & READ) && ar->childType == kMIDIObjectType_Source
+				&& ctx[0].ep == 0 && strcmp(name, g_src_name) == 0) {
+			ctx[0].ep = (MIDIEndpointRef)obj;
+			err = MIDIPortConnectSource(ctx[0].port, ctx[0].ep, NULL);
+			if (err)
+				fprintf(stderr, "coremidiio: MIDIPortConnectSource: %d\n", (int)err);
+		}
+		if ((g_mode & WRITE) && ar->childType == kMIDIObjectType_Destination
+				&& ctx[1].ep == 0 && strcmp(name, g_dst_name) == 0) {
+			ctx[1].ep = (MIDIEndpointRef)obj;
+		}
+		reader_ok = !(g_mode & READ) || ctx[0].ep != 0;
+		writer_ok = !(g_mode & WRITE) || ctx[1].ep != 0;
+		if (reader_ok && writer_ok) {
+			g_connected = true;
+			if (g_ctrl_wfd >= 0) {
+				sig = 0x01;
+				write(g_ctrl_wfd, &sig, 1);
+			}
+			fprintf(stderr, "coremidiio: device reconnected\n");
+		}
 	}
 }
 
@@ -315,6 +371,7 @@ main(int argc, char *argv[])
 	CFStringRef name;
 	int mode;
 	struct context ctx[2];
+	int ctrl[2];
 
 	port[0] = -1;
 	port[1] = -1;
@@ -349,15 +406,32 @@ main(int argc, char *argv[])
 
 	if (mode == 0)
 		mode = READ | WRITE;
-	if (argc)
-		spawn(argv[0], argv, mode, fd);
+	g_mode = mode;
+
+	if (argc) {
+		/* Create control pipe: read end goes to fd 8 in oscmix,
+		 * write end stays here for disconnect/reconnect signals. */
+		if (pipe(ctrl) != 0)
+			fatal("pipe:");
+		fcntl(ctrl[1], F_SETFD, FD_CLOEXEC);
+		g_ctrl_wfd = ctrl[1];
+		spawn(argv[0], argv, mode, fd, ctrl[0]);
+		/* ctrl[0] was closed inside spawn(); g_ctrl_wfd=ctrl[1] is ours. */
+	}
 
 	err = MIDIClientCreate(name, notify, ctx, &client);
 	if (err)
 		fatal("MIDIClientCreate: %d", err);
-	if (mode & READ)
+	if (mode & READ) {
 		initreader(&ctx[0], client, name, port[0], fd[1]);
-	if (mode & WRITE)
+		if (port[0] != -1)
+			epname(ctx[0].ep, g_src_name, sizeof g_src_name);
+	}
+	if (mode & WRITE) {
 		initwriter(&ctx[1], client, name, port[1], fd[0]);
+		if (port[1] != -1)
+			epname(ctx[1].ep, g_dst_name, sizeof g_dst_name);
+	}
+	g_connected = true;
 	CFRunLoopRun();
 }

--- a/gtk/main.c
+++ b/gtk/main.c
@@ -19,15 +19,13 @@ static const struct device *devices[] = {
 };
 static const int devices_count = sizeof(devices) / sizeof(devices[0]);
 
-/* Timeout in seconds to wait for /device before prompting offline mode */
-#define DEVICE_DETECT_TIMEOUT_S 5
-
 
 struct _OSCMixWindow {
 	GtkApplicationWindow base;
 	Mixer *osc;
-	const struct device *current_device;  /* set via /device OSC or offline dialog */
-	guint device_timeout_source;          /* GSource id for detect timeout, 0 when inactive */
+	const struct device *current_device;  /* set via /device/id OSC */
+	GtkStack *root_stack;                 /* "scanning" | "mixer" pages */
+	gchar *pending_device_id;             /* last non-empty /device/id seen */
 	gpointer send_host;
 	gpointer send_port;
 	gpointer recv_host;
@@ -394,17 +392,63 @@ static void output_modify(GtkTreeModel *model, GtkTreeIter *iter, GValue *val, i
 static void setup_channels(OSCMixWindow *self, const struct device *dev, ChannelType type, GtkBox *box);
 
 /*
- * apply_device - finalize device selection and build channel UI.
- * Called either from on_device_osc (auto-detect) or after offline dialog.
- * Cancels the pending timeout if still active.
+ * clear_device - tear down channel widgets and models built by
+ * apply_device() so we can rebuild cleanly on reconnect. Called
+ * both from apply_device (to free stale state) and from the
+ * /device/id offline transition.
+ */
+static void
+clear_device(OSCMixWindow *self)
+{
+	GList *children, *l;
+
+	if (!self->current_device && !self->inputs_array)
+		return;
+
+	/* Destroy any existing channel widgets held by the three boxes;
+	 * setup_channels will repopulate them on reconnect. */
+	if (self->inputs) {
+		children = gtk_container_get_children(GTK_CONTAINER(self->inputs));
+		for (l = children; l; l = l->next)
+			gtk_widget_destroy(GTK_WIDGET(l->data));
+		g_list_free(children);
+	}
+	if (self->playbacks) {
+		children = gtk_container_get_children(GTK_CONTAINER(self->playbacks));
+		for (l = children; l; l = l->next)
+			gtk_widget_destroy(GTK_WIDGET(l->data));
+		g_list_free(children);
+	}
+	if (self->outputs) {
+		children = gtk_container_get_children(GTK_CONTAINER(self->outputs));
+		for (l = children; l; l = l->next)
+			gtk_widget_destroy(GTK_WIDGET(l->data));
+		g_list_free(children);
+	}
+
+	if (self->inputs_array) {
+		g_ptr_array_free(self->inputs_array, TRUE);
+		self->inputs_array = NULL;
+	}
+	if (self->outputs_model) {
+		g_object_unref(self->outputs_model);
+		self->outputs_model = NULL;
+	}
+	if (self->outputs_store) {
+		g_object_unref(self->outputs_store);
+		self->outputs_store = NULL;
+	}
+	self->current_device = NULL;
+}
+
+/*
+ * apply_device - build channel UI for the detected device and
+ * switch the root stack to the mixer page.
  */
 static void
 apply_device(OSCMixWindow *self, const struct device *dev)
 {
-	if (self->device_timeout_source != 0) {
-		g_source_remove(self->device_timeout_source);
-		self->device_timeout_source = 0;
-	}
+	clear_device(self);
 	self->current_device = dev;
 
 	self->inputs_array = g_ptr_array_new();
@@ -416,80 +460,17 @@ apply_device(OSCMixWindow *self, const struct device *dev)
 	setup_channels(self, dev, CHANNEL_TYPE_OUTPUT, self->outputs);
 	setup_channels(self, dev, CHANNEL_TYPE_INPUT, self->inputs);
 	setup_channels(self, dev, CHANNEL_TYPE_PLAYBACK, self->playbacks);
+
+	if (self->root_stack)
+		gtk_stack_set_visible_child_name(self->root_stack, "mixer");
 }
 
 /*
- * show_offline_device_dialog - prompt user to select a device for offline use.
- * Returns the selected device, or NULL if cancelled.
- */
-static const struct device *
-show_offline_device_dialog(GtkWindow *parent)
-{
-	GtkWidget *dialog, *combo, *content;
-	const struct device *selected = NULL;
-	int i, response;
-
-	dialog = gtk_dialog_new_with_buttons(
-										 "Select Device (Offline Mode)",
-										 parent,
-										 GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-										 "_Cancel", GTK_RESPONSE_CANCEL,
-										 "_OK",     GTK_RESPONSE_OK,
-										 NULL);
-	gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_OK);
-
-	combo = gtk_combo_box_text_new();
-	for (i = 0; i < devices_count; ++i)
-		gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(combo), devices[i]->id, devices[i]->name);
-	gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 0);
-
-	content = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
-	gtk_container_set_border_width(GTK_CONTAINER(content), 12);
-	gtk_box_pack_start(GTK_BOX(content),
-					   gtk_label_new("No device was detected. Select a device to use in offline mode:"),
-					   FALSE, FALSE, 8);
-	gtk_box_pack_start(GTK_BOX(content), combo, FALSE, FALSE, 4);
-	gtk_widget_show_all(dialog);
-
-	response = gtk_dialog_run(GTK_DIALOG(dialog));
-	if (response == GTK_RESPONSE_OK) {
-		const char *id = gtk_combo_box_get_active_id(GTK_COMBO_BOX(combo));
-		for (i = 0; i < devices_count; ++i) {
-			if (g_strcmp0(devices[i]->id, id) == 0) {
-				selected = devices[i];
-				break;
-			}
-		}
-	}
-	gtk_widget_destroy(dialog);
-	return selected;
-}
-
-/*
- * on_device_timeout - fires if no /device message arrived within the timeout.
- * Shows the offline device selection dialog.
- */
-static gboolean
-on_device_timeout(gpointer ptr)
-{
-	OSCMixWindow *self = OSCMIX_WINDOW(ptr);
-	const struct device *dev;
-
-	self->device_timeout_source = 0;  /* source has fired, mark as inactive */
-
-	dev = show_offline_device_dialog(GTK_WINDOW(self));
-	if (dev)
-		apply_device(self, dev);
-
-	return G_SOURCE_REMOVE;
-}
-
-/*
- * on_device_osc - called when oscmix sends /device with ",ss" (id, name).
- * Matches the id against the known devices array and applies the device.
+ * on_device_id - handler for /device/id. An empty string signals the
+ * backend has lost the device; a non-empty id names the connected unit.
  */
 static void
-on_device_osc(GValue *arg, guint len, gpointer ptr)
+on_device_id(GValue *arg, guint len, gpointer ptr)
 {
 	OSCMixWindow *self = OSCMIX_WINDOW(ptr);
 	const char *id;
@@ -497,19 +478,35 @@ on_device_osc(GValue *arg, guint len, gpointer ptr)
 
 	if (len < 1 || !G_VALUE_HOLDS_STRING(&arg[0]))
 		return;
-
-	/* Ignore if device already set (e.g. repeated /refresh) */
-	if (self->current_device)
+	id = g_value_get_string(&arg[0]);
+	if (!id)
 		return;
 
-	id = g_value_get_string(&arg[0]);
+	if (*id == '\0') {
+		/* Offline: return to the scanning page. */
+		if (self->current_device || self->root_stack) {
+			clear_device(self);
+			if (self->root_stack)
+				gtk_stack_set_visible_child_name(self->root_stack, "scanning");
+		}
+		g_clear_pointer(&self->pending_device_id, g_free);
+		return;
+	}
+
+	/* Already showing this device, nothing to do. */
+	if (self->current_device && g_strcmp0(self->current_device->id, id) == 0)
+		return;
+
 	for (i = 0; i < devices_count; ++i) {
 		if (g_strcmp0(devices[i]->id, id) == 0) {
 			apply_device(self, devices[i]);
+			g_clear_pointer(&self->pending_device_id, g_free);
 			return;
 		}
 	}
-	g_warning("on_device_osc: unknown device id '%s'", id);
+	g_warning("on_device_id: unknown device id '%s'", id);
+	g_free(self->pending_device_id);
+	self->pending_device_id = g_strdup(id);
 }
 
 static void
@@ -561,6 +558,8 @@ oscmix_window_class_init(OSCMixWindowClass *class)
 	gtk_widget_class_bind_template_child(GTK_WIDGET_CLASS(class), OSCMixWindow, standalonearc);
 	gtk_widget_class_bind_template_child(GTK_WIDGET_CLASS(class), OSCMixWindow, lockkeys);
 	gtk_widget_class_bind_template_child(GTK_WIDGET_CLASS(class), OSCMixWindow, remapkeys);
+
+	gtk_widget_class_bind_template_child(GTK_WIDGET_CLASS(class), OSCMixWindow, root_stack);
 
 	gtk_widget_class_bind_template_child(GTK_WIDGET_CLASS(class), OSCMixWindow, inputs);
 	gtk_widget_class_bind_template_child(GTK_WIDGET_CLASS(class), OSCMixWindow, playbacks);
@@ -691,7 +690,13 @@ oscmix_window_init(OSCMixWindow *self)
 	gtk_widget_init_template(GTK_WIDGET(self));
 	self->osc = mixer_new();
 	self->current_device = NULL;
-	self->device_timeout_source = 0;
+	self->pending_device_id = NULL;
+	self->inputs_array = NULL;
+	self->outputs_store = NULL;
+	self->outputs_model = NULL;
+
+	if (self->root_stack)
+		gtk_stack_set_visible_child_name(self->root_stack, "scanning");
 
 	settings = g_settings_new("oscmix");
 	g_settings_bind(settings, "send-host", self->send_host, "text", G_SETTINGS_BIND_DEFAULT);
@@ -747,12 +752,11 @@ oscmix_window_init(OSCMixWindow *self)
 	mixer_bind(self->osc, "/durec/file", G_TYPE_INT, self->durec_file, "active");
 	g_signal_connect(self->durec_file, "changed", G_CALLBACK(on_durec_file_changed), self);
 
-	/* Register /device handler - fires when oscmix identifies itself on /refresh */
-	mixer_connect(self->osc, "/device", on_device_osc, self);
-
-	/* Start timeout - if no /device arrives within the window, show offline dialog */
-	self->device_timeout_source = g_timeout_add_seconds(
-														DEVICE_DETECT_TIMEOUT_S, on_device_timeout, self);
+	/* Register /device/id handler. An empty id means the backend lost
+	 * the device and the UI should return to the scanning page; a
+	 * non-empty id names the connected unit. /device/name is ignored
+	 * because /device/id already drives the state machine. */
+	mixer_connect(self->osc, "/device/id", on_device_id, self);
 
 	g_signal_emit_by_name(self->send_host, "activate");
 	g_signal_emit_by_name(self->recv_host, "activate");

--- a/gtk/main.c
+++ b/gtk/main.c
@@ -204,6 +204,8 @@ on_mainout_osc(GValue *arg, guint len, gpointer ptr)
 	if (len == 0)
 		return;
 	self = OSCMIX_WINDOW(ptr);
+	if (!self->outputs_model)
+		return;
 	g_value_init(&val, G_TYPE_INT);
 	if (!g_value_transform(&arg[0], &val))
 		return;
@@ -758,8 +760,8 @@ oscmix_window_init(OSCMixWindow *self)
 	 * because /device/id already drives the state machine. */
 	mixer_connect(self->osc, "/device/id", on_device_id, self);
 
-	g_signal_emit_by_name(self->send_host, "activate");
 	g_signal_emit_by_name(self->recv_host, "activate");
+	g_signal_emit_by_name(self->send_host, "activate");
 }
 
 static void

--- a/gtk/oscmix.ui
+++ b/gtk/oscmix.ui
@@ -12,19 +12,59 @@
 			</object>
 		</child>
 		<child>
-			<object class="GtkPaned">
+			<object class="GtkStack" id="root_stack">
 				<property name="visible">true</property>
+				<property name="transition-type">crossfade</property>
 				<child>
 					<object class="GtkBox">
 						<property name="visible">true</property>
 						<property name="orientation">vertical</property>
-						<property name="homogeneous">true</property>
-						<property name="border-width">8</property>
-						<property name="expand">true</property>
+						<property name="halign">center</property>
+						<property name="valign">center</property>
+						<property name="spacing">20</property>
 						<child>
-							<object class="GtkFrame">
+							<object class="GtkSpinner">
 								<property name="visible">true</property>
-								<property name="label">Input</property>
+								<property name="active">true</property>
+								<property name="width-request">64</property>
+								<property name="height-request">64</property>
+							</object>
+						</child>
+						<child>
+							<object class="GtkLabel">
+								<property name="visible">true</property>
+								<property name="label">Scanning for devices…</property>
+								<attributes>
+									<attribute name="weight" value="bold"/>
+									<attribute name="scale" value="1.3"/>
+								</attributes>
+							</object>
+						</child>
+						<child>
+							<object class="GtkLabel">
+								<property name="visible">true</property>
+								<property name="label">Make sure your RME interface is powered on and connected via USB.</property>
+							</object>
+						</child>
+					</object>
+					<packing>
+						<property name="name">scanning</property>
+					</packing>
+				</child>
+				<child>
+					<object class="GtkPaned">
+						<property name="visible">true</property>
+						<child>
+							<object class="GtkBox">
+								<property name="visible">true</property>
+								<property name="orientation">vertical</property>
+								<property name="homogeneous">true</property>
+								<property name="border-width">8</property>
+								<property name="expand">true</property>
+								<child>
+									<object class="GtkFrame">
+										<property name="visible">true</property>
+										<property name="label">Input</property>
 								<child>
 									<object class="GtkScrolledWindow">
 										<property name="visible">true</property>
@@ -1523,6 +1563,11 @@
 					<packing>
 						<property name="shrink">false</property>
 						<property name="resize">false</property>
+					</packing>
+				</child>
+					</object>
+					<packing>
+						<property name="name">mixer</property>
 					</packing>
 				</child>
 			</object>

--- a/main.c
+++ b/main.c
@@ -302,7 +302,7 @@ main(int argc, char *argv[])
 	char *recvaddr, *sendaddr;
 	struct itimerval it;
 	struct sigaction sa;
-	struct pollfd pfd[2];
+	struct pollfd pfd[3];
 	const char *port;
 	int mflag = 0, zflag = 0;
 
@@ -462,9 +462,17 @@ main(int argc, char *argv[])
 	if (setitimer(ITIMER_REAL, &it, NULL) != 0)
 		fatal("setitimer:");
 
+	/* Control pipe from coremidiio: fd 8 carries 0x00 (offline) / 0x01 (online)
+	 * signals for macOS hotplug.  Only active in wrapper mode. */
+	int ctrl_fd = -1;
+	if (!self_opened_midi && fcntl(8, F_GETFD) >= 0)
+		ctrl_fd = 8;
+
 	pfd[0].events = POLLIN;
 	pfd[1].fd = rfd;
 	pfd[1].events = POLLIN;
+	pfd[2].fd = ctrl_fd;  /* -1 → ignored by poll() */
+	pfd[2].events = POLLIN;
 
 	bool online = have_midi;
 	if (online) {
@@ -481,7 +489,7 @@ main(int argc, char *argv[])
 	int scan_tick = 0;
 
 	for (;;) {
-		if (poll(pfd, 2, -1) < 0 && errno != EINTR)
+		if (poll(pfd, 3, -1) < 0 && errno != EINTR)
 			fatal("poll:");
 
 		if (online && (pfd[0].revents & POLLIN ||
@@ -514,6 +522,25 @@ main(int argc, char *argv[])
 				ssize_t ret = read(rfd, buf, sizeof buf);
 				(void)ret;
 				oscmix_announce_offline();
+			}
+		}
+
+		/* Control signal from coremidiio: 0x00=offline, 0x01=online */
+		if (ctrl_fd >= 0 && (pfd[2].revents & POLLIN)) {
+			unsigned char sig;
+			if (read(ctrl_fd, &sig, 1) == 1) {
+				if (sig == 0x00 && online) {
+					fprintf(stderr, "oscmix: midi device disconnected\n");
+					pfd[0].fd = -1;
+					online = false;
+					oscmix_announce_offline();
+					scan_tick = 0;
+				} else if (sig == 0x01 && !online) {
+					fprintf(stderr, "oscmix: midi device (re)connected\n");
+					pfd[0].fd = 6;
+					online = true;
+					handleosc(refreshosc, sizeof refreshosc - 1);
+				}
 			}
 		}
 

--- a/main.c
+++ b/main.c
@@ -11,6 +11,11 @@
 #include <poll.h>
 #include <sys/time.h>
 #include <unistd.h>
+#ifdef __linux__
+#include <sys/ioctl.h>
+#include <sound/asound.h>
+#include "usbscan.h"
+#endif
 #include "oscmix.h"
 #include "arg.h"
 #include "socket.h"
@@ -24,6 +29,125 @@ extern int dflag;
 static int lflag;
 static int rfd, wfd;
 static volatile sig_atomic_t timeout;
+
+/* When true, oscmix itself owns the midi fds (opened by openmidi());
+ * on disconnect we close and re-open instead of bailing out. When false,
+ * the fds were inherited from a wrapper (alsarawio / alsaseqio / coremidiio)
+ * and we preserve the original fatal-on-error semantics. */
+static bool self_opened_midi;
+
+#ifdef __linux__
+/* Device name prefixes matched against snd_ctl_card_info.name.
+ * Order matters: longer prefixes must come before their shorter cousins
+ * because we use strncmp (e.g. "Fireface UCX II" before "Fireface UCX"). */
+static const char *const midi_devices[] = {
+	"Fireface UCX II",
+	"Fireface UFX III",
+	"Fireface UFX II",
+	"Fireface UFX+",
+	"Fireface 802",
+	"Fireface UCX",
+	NULL,
+};
+static char midiport[80];
+
+static int
+openmidi(void)
+{
+	int card, ctlfd, midifd, ver, i;
+	char path[64];
+	struct snd_ctl_card_info cardinfo;
+	struct snd_rawmidi_info info;
+	struct snd_rawmidi_params params;
+
+	for (card = 0; card <= 31; ++card) {
+		snprintf(path, sizeof path, "/dev/snd/controlC%d", card);
+		ctlfd = open(path, O_RDONLY | O_CLOEXEC);
+		if (ctlfd < 0)
+			continue;
+		if (ioctl(ctlfd, SNDRV_CTL_IOCTL_CARD_INFO, &cardinfo) != 0) {
+			close(ctlfd);
+			continue;
+		}
+		for (i = 0; midi_devices[i]; ++i) {
+			if (strncmp((char *)cardinfo.name, midi_devices[i], strlen(midi_devices[i])) != 0)
+				continue;
+			if (ioctl(ctlfd, SNDRV_CTL_IOCTL_RAWMIDI_PREFER_SUBDEVICE, &(int){1}) != 0) {
+				perror("ioctl SNDRV_CTL_IOCTL_RAWMIDI_PREFER_SUBDEVICE");
+				close(ctlfd);
+				return -1;
+			}
+			snprintf(path, sizeof path, "/dev/snd/midiC%dD0", card);
+			midifd = open(path, O_RDWR | O_CLOEXEC);
+			close(ctlfd);
+			if (midifd < 0) {
+				fprintf(stderr, "open %s: %s\n", path, strerror(errno));
+				return -1;
+			}
+			if (ioctl(midifd, (int)SNDRV_RAWMIDI_IOCTL_PVERSION, &ver) != 0) {
+				perror("ioctl SNDRV_RAWMIDI_IOCTL_PVERSION");
+				close(midifd);
+				return -1;
+			}
+			if (SNDRV_PROTOCOL_INCOMPATIBLE(ver, SNDRV_RAWMIDI_VERSION)) {
+				fprintf(stderr, "incompatible rawmidi version\n");
+				close(midifd);
+				return -1;
+			}
+			memset(&info, 0, sizeof info);
+			info.stream = SNDRV_RAWMIDI_STREAM_INPUT;
+			if (ioctl(midifd, (int)SNDRV_RAWMIDI_IOCTL_INFO, &info) != 0) {
+				perror("ioctl SNDRV_RAWMIDI_IOCTL_INFO");
+				close(midifd);
+				return -1;
+			}
+			if (info.subdevice != 1) {
+				fprintf(stderr, "could not open subdevice 1\n");
+				close(midifd);
+				return -1;
+			}
+			snprintf(midiport, sizeof midiport, "%s", (char *)info.subname);
+
+			memset(&params, 0, sizeof params);
+			params.stream = SNDRV_RAWMIDI_STREAM_INPUT;
+			params.buffer_size = 8192;
+			params.avail_min = 1;
+			params.no_active_sensing = 1;
+			if (ioctl(midifd, (int)SNDRV_RAWMIDI_IOCTL_PARAMS, &params) != 0) {
+				perror("ioctl SNDRV_RAWMIDI_IOCTL_PARAMS");
+				close(midifd);
+				return -1;
+			}
+			params.stream = SNDRV_RAWMIDI_STREAM_OUTPUT;
+			if (ioctl(midifd, (int)SNDRV_RAWMIDI_IOCTL_PARAMS, &params) != 0) {
+				perror("ioctl SNDRV_RAWMIDI_IOCTL_PARAMS");
+				close(midifd);
+				return -1;
+			}
+			if (dup2(midifd, 6) < 0 || dup2(midifd, 7) < 0) {
+				perror("dup2");
+				close(midifd);
+				return -1;
+			}
+			close(midifd);
+			return 0;
+		}
+		close(ctlfd);
+	}
+	return -1;
+}
+
+static void
+close_midi(void)
+{
+	/* Close fds 6 and 7 and leave them unallocated. poll() with fd=-1
+	 * simply ignores the entry, so the scan loop can run without a
+	 * midi fd until openmidi() succeeds again. */
+	close(6);
+	close(7);
+}
+
+#endif /* __linux__ */
 
 static void
 usage(int status)
@@ -50,7 +174,11 @@ usage(int status)
 	exit(status);
 }
 
-static void
+/* Returns 0 on success (including partial read), -1 if the midi device
+ * went away (EIO / ENODEV / EBADF / ENXIO / unexpected EOF). Other errors
+ * still call fatal() to preserve the previous behavior for truly
+ * unexpected failures. */
+static int
 midiread(int fd)
 {
 	static unsigned char data[8192], *dataend = data;
@@ -59,8 +187,23 @@ midiread(int fd)
 	ssize_t ret;
 
 	ret = read(fd, dataend, (data + sizeof data) - dataend);
-	if (ret < 0)
+	if (ret < 0) {
+		if (self_opened_midi && (errno == EIO || errno == ENODEV
+				|| errno == EBADF || errno == ENXIO))
+			return -1;
 		fatal("read %d:", fd);
+	}
+	if (ret == 0) {
+		/* Driver signaled EOF: only treat as disconnect when we own
+		 * the fd ourselves. Wrapper-inherited mode keeps the old
+		 * behavior of falling through (which would be a no-op read). */
+		if (self_opened_midi) {
+			dataend = data;
+			return -1;
+		}
+		dataend = data;
+		return 0;
+	}
 	dataend += ret;
 	datapos = data;
 	for (;;) {
@@ -85,6 +228,7 @@ midiread(int fd)
 		handlesysex(datapos, nextpos - datapos, payload);
 		datapos = nextpos;
 	}
+	return 0;
 }
 
 static void
@@ -110,8 +254,16 @@ writemidi(const void *buf, size_t len)
 	pos = buf;
 	while (len > 0) {
 		ret = write(7, pos, len);
-		if (ret < 0)
+		if (ret < 0) {
+			if (self_opened_midi && (errno == EIO || errno == ENODEV
+					|| errno == EBADF || errno == ENXIO || errno == EPIPE)) {
+				/* Device went away while we were writing. The read
+				 * side will see the same error next poll cycle and
+				 * transition to scanning state; drop the packet. */
+				return;
+			}
 			fatal("write 7:");
+		}
 		pos += ret;
 		len -= ret;
 	}
@@ -212,11 +364,30 @@ main(int argc, char *argv[])
 		}
 	}
 
-	if (fcntl(6, F_GETFD) < 0 || fcntl(7, F_GETFD) < 0) {
+	bool have_midi = (fcntl(6, F_GETFD) >= 0 && fcntl(7, F_GETFD) >= 0);
+
+	if (!have_midi) {
+#ifdef __linux__
+		/* No wrapper present: scan /dev/snd/controlC* ourselves for
+		 * a supported RME card. If nothing is connected yet we still
+		 * proceed — the poll loop below will keep retrying and the
+		 * daemon stays alive, announcing an offline state to
+		 * frontends until a device shows up. */
+		self_opened_midi = true;
+		if (openmidi() == 0) {
+			have_midi = true;
+			if (!port)
+				port = midiport;
+		} else {
+			fprintf(stderr, "oscmix: no supported RME device found; "
+					"waiting for a device to be connected...\n");
+		}
+#else
 		fprintf(stderr, "error: MIDI file descriptors 6 and 7 are not open.\n"
 				"       Use alsarawio, alsaseqio (Linux) or coremidiio (macOS)\n"
 				"       to set up MIDI I/O before invoking oscmix.\n\n");
 		usage(1);
+#endif
 	}
 
 	uint16_t recvport = sockaddrport(recvaddr);
@@ -225,16 +396,20 @@ main(int argc, char *argv[])
 	rfd = sockopen(recvaddr, 1);
 	wfd = sockopen(sendaddr, 0);
 
-	if (!port) {
-		port = getenv("MIDIPORT");
-		if (!port)
-			fatal("device is not specified; pass -p or set MIDIPORT");
+	bool initialized = false;
+	if (have_midi) {
+		if (!port) {
+			port = getenv("MIDIPORT");
+			if (!port)
+				fatal("device is not specified; pass -p or set MIDIPORT");
+		}
+		if (init(port) != 0)
+			return 1;
+		initialized = true;
 	}
-	if (init(port) != 0)
-		return 1;
 
 #ifdef HAVE_MDNS
-	if (zflag) {
+	if (zflag && have_midi) {
 		struct oscmix_devinfo dev;
 		char svc_name[320];
 		char txt_id[80], txt_uid[320], txt_flags[32];
@@ -285,21 +460,112 @@ main(int argc, char *argv[])
 	if (setitimer(ITIMER_REAL, &it, NULL) != 0)
 		fatal("setitimer:");
 
-	pfd[0].fd = 6;
 	pfd[0].events = POLLIN;
 	pfd[1].fd = rfd;
 	pfd[1].events = POLLIN;
-	handleosc(refreshosc, sizeof refreshosc - 1);
+
+	bool online = have_midi;
+	if (online) {
+		pfd[0].fd = 6;
+		handleosc(refreshosc, sizeof refreshosc - 1);
+	} else {
+		pfd[0].fd = -1;   /* ignored by poll() */
+		oscmix_announce_offline();
+	}
+
+	/* 100ms timer ticks; every 10 ticks (= 1s) we try openmidi() again
+	 * while offline, and re-announce the offline state so frontends
+	 * that connected after we went offline catch the signal. */
+	int scan_tick = 0;
+
 	for (;;) {
 		if (poll(pfd, 2, -1) < 0 && errno != EINTR)
 			fatal("poll:");
-		if (pfd[0].revents & POLLIN)
-			midiread(6);
-		if (pfd[1].revents & POLLIN)
-			oscread(rfd);
+
+		if (online && (pfd[0].revents & POLLIN)) {
+			if (midiread(6) < 0) {
+				/* Device went away. Transition to scanning state:
+				 * close the midi fds, tell frontends, and have the
+				 * poll loop stop reading midi until openmidi()
+				 * succeeds again. */
+				fprintf(stderr, "oscmix: midi device disconnected; "
+						"entering scanning state\n");
+#ifdef __linux__
+				close_midi();
+#endif
+				pfd[0].fd = -1;
+				online = false;
+				oscmix_announce_offline();
+				scan_tick = 0;
+			}
+		}
+
+		if (pfd[1].revents & POLLIN) {
+			if (online) {
+				oscread(rfd);
+			} else {
+				/* Drain any incoming OSC while offline and
+				 * re-announce; a frontend that sends /refresh
+				 * gets a prompt offline acknowledgement. */
+				unsigned char buf[8192];
+				ssize_t ret = read(rfd, buf, sizeof buf);
+				(void)ret;
+				oscmix_announce_offline();
+			}
+		}
+
 		if (timeout) {
 			timeout = 0;
-			handletimer(lflag == 0);
+			if (online) {
+				handletimer(lflag == 0);
+			} else if (++scan_tick >= 10) {
+				scan_tick = 0;
+				oscmix_announce_offline();
+#ifdef __linux__
+				if (self_opened_midi && openmidi() != 0) {
+					/* ALSA scan came up empty. Probe sysfs
+					 * for a plugged-in RME device; a positive
+					 * hit without an ALSA card means the
+					 * kernel driver hasn't bound yet, so
+					 * log and keep retrying instead of
+					 * treating the absence as fatal. */
+					const char *usb_id = NULL;
+					if (usbscan_find(&usb_id)) {
+						static bool logged_race;
+						if (!logged_race) {
+							fprintf(stderr, "oscmix: detected "
+								"RME device (%s) via USB but "
+								"ALSA card not ready yet; "
+								"waiting...\n", usb_id);
+							logged_race = true;
+						}
+					}
+				} else if (self_opened_midi) {
+					/* First-time startup also lands here
+					 * if the device was offline when oscmix
+					 * launched; init() hasn't run yet in
+					 * that case. */
+					if (!initialized) {
+						const char *p = port ? port : midiport;
+						if (init(p) != 0) {
+							fprintf(stderr, "oscmix: init "
+								"failed for '%s'; will keep "
+								"scanning\n", p);
+							close_midi();
+							pfd[0].fd = -1;
+							continue;
+						}
+						initialized = true;
+					}
+					fprintf(stderr, "oscmix: midi device "
+						"(re)connected\n");
+					pfd[0].fd = 6;
+					online = true;
+					handleosc(refreshosc,
+						sizeof refreshosc - 1);
+				}
+#endif
+			}
 		}
 	}
 }

--- a/main.c
+++ b/main.c
@@ -484,7 +484,7 @@ main(int argc, char *argv[])
 		if (poll(pfd, 2, -1) < 0 && errno != EINTR)
 			fatal("poll:");
 
-		if (online && (pfd[0].revents & POLLIN)) {
+		if (online && (pfd[0].revents & (POLLIN | POLLHUP | POLLERR))) {
 			if (midiread(6) < 0) {
 				/* Device went away. Transition to scanning state:
 				 * close the midi fds, tell frontends, and have the

--- a/main.c
+++ b/main.c
@@ -126,10 +126,12 @@ openmidi(void)
 			}
 			if (dup2(midifd, 6) < 0 || dup2(midifd, 7) < 0) {
 				perror("dup2");
-				close(midifd);
+				if (midifd != 6 && midifd != 7)
+					close(midifd);
 				return -1;
 			}
-			close(midifd);
+			if (midifd != 6 && midifd != 7)
+				close(midifd);
 			return 0;
 		}
 		close(ctlfd);

--- a/main.c
+++ b/main.c
@@ -484,7 +484,8 @@ main(int argc, char *argv[])
 		if (poll(pfd, 2, -1) < 0 && errno != EINTR)
 			fatal("poll:");
 
-		if (online && (pfd[0].revents & (POLLIN | POLLHUP | POLLERR))) {
+		if (online && (pfd[0].revents & POLLIN ||
+				(self_opened_midi && (pfd[0].revents & (POLLHUP | POLLERR))))) {
 			if (midiread(6) < 0) {
 				/* Device went away. Transition to scanning state:
 				 * close the midi fds, tell frontends, and have the

--- a/main.c
+++ b/main.c
@@ -35,6 +35,10 @@ static volatile sig_atomic_t timeout;
  * the fds were inherited from a wrapper (alsarawio / alsaseqio / coremidiio)
  * and we preserve the original fatal-on-error semantics. */
 static bool self_opened_midi;
+/* Set when the USB-present-but-ALSA-not-ready race has been logged, so we
+ * don't repeat it every second. Reset each time the device goes offline so
+ * the next fast-reconnect cycle logs again if the race recurs. */
+static bool logged_race;
 
 #ifdef __linux__
 /* Device name prefixes matched against snd_ctl_card_info.name.
@@ -74,37 +78,37 @@ openmidi(void)
 				continue;
 			if (ioctl(ctlfd, SNDRV_CTL_IOCTL_RAWMIDI_PREFER_SUBDEVICE, &(int){1}) != 0) {
 				perror("ioctl SNDRV_CTL_IOCTL_RAWMIDI_PREFER_SUBDEVICE");
-				close(ctlfd);
-				return -1;
+				break;  /* try next card; outer loop closes ctlfd */
 			}
 			snprintf(path, sizeof path, "/dev/snd/midiC%dD0", card);
 			midifd = open(path, O_RDWR | O_CLOEXEC);
 			close(ctlfd);
+			ctlfd = -1;  /* closed; prevent double-close by outer loop */
 			if (midifd < 0) {
 				fprintf(stderr, "open %s: %s\n", path, strerror(errno));
-				return -1;
+				break;
 			}
 			if (ioctl(midifd, (int)SNDRV_RAWMIDI_IOCTL_PVERSION, &ver) != 0) {
 				perror("ioctl SNDRV_RAWMIDI_IOCTL_PVERSION");
 				close(midifd);
-				return -1;
+				break;
 			}
 			if (SNDRV_PROTOCOL_INCOMPATIBLE(ver, SNDRV_RAWMIDI_VERSION)) {
 				fprintf(stderr, "incompatible rawmidi version\n");
 				close(midifd);
-				return -1;
+				break;
 			}
 			memset(&info, 0, sizeof info);
 			info.stream = SNDRV_RAWMIDI_STREAM_INPUT;
 			if (ioctl(midifd, (int)SNDRV_RAWMIDI_IOCTL_INFO, &info) != 0) {
 				perror("ioctl SNDRV_RAWMIDI_IOCTL_INFO");
 				close(midifd);
-				return -1;
+				break;
 			}
 			if (info.subdevice != 1) {
 				fprintf(stderr, "could not open subdevice 1\n");
 				close(midifd);
-				return -1;
+				break;
 			}
 			snprintf(midiport, sizeof midiport, "%s", (char *)info.subname);
 
@@ -116,25 +120,26 @@ openmidi(void)
 			if (ioctl(midifd, (int)SNDRV_RAWMIDI_IOCTL_PARAMS, &params) != 0) {
 				perror("ioctl SNDRV_RAWMIDI_IOCTL_PARAMS");
 				close(midifd);
-				return -1;
+				break;
 			}
 			params.stream = SNDRV_RAWMIDI_STREAM_OUTPUT;
 			if (ioctl(midifd, (int)SNDRV_RAWMIDI_IOCTL_PARAMS, &params) != 0) {
 				perror("ioctl SNDRV_RAWMIDI_IOCTL_PARAMS");
 				close(midifd);
-				return -1;
+				break;
 			}
 			if (dup2(midifd, 6) < 0 || dup2(midifd, 7) < 0) {
 				perror("dup2");
 				if (midifd != 6 && midifd != 7)
 					close(midifd);
-				return -1;
+				break;
 			}
 			if (midifd != 6 && midifd != 7)
 				close(midifd);
 			return 0;
 		}
-		close(ctlfd);
+		if (ctlfd >= 0)
+			close(ctlfd);
 	}
 	return -1;
 }
@@ -176,6 +181,20 @@ usage(int status)
 	exit(status);
 }
 
+/* SysEx reassembly buffer. Lifted out of midiread() so that the disconnect
+ * transitions in the poll loop can clear any partial data that was
+ * mid-stream when the device went away — otherwise stale bytes would be
+ * concatenated with fresh bytes on reconnect and parsed as one corrupt
+ * SysEx packet. */
+static unsigned char midibuf[8192];
+static unsigned char *midibufend = midibuf;
+
+static void
+midireset(void)
+{
+	midibufend = midibuf;
+}
+
 /* Returns 0 on success (including partial read), -1 if the midi device
  * went away (EIO / ENODEV / EBADF / ENXIO / unexpected EOF). Other errors
  * still call fatal() to preserve the previous behavior for truly
@@ -183,16 +202,17 @@ usage(int status)
 static int
 midiread(int fd)
 {
-	static unsigned char data[8192], *dataend = data;
 	unsigned char *datapos, *nextpos;
-	uint_least32_t payload[sizeof data / 4];
+	uint_least32_t payload[sizeof midibuf / 4];
 	ssize_t ret;
 
-	ret = read(fd, dataend, (data + sizeof data) - dataend);
+	ret = read(fd, midibufend, (midibuf + sizeof midibuf) - midibufend);
 	if (ret < 0) {
 		if (self_opened_midi && (errno == EIO || errno == ENODEV
-				|| errno == EBADF || errno == ENXIO))
+				|| errno == EBADF || errno == ENXIO)) {
+			midireset();
 			return -1;
+		}
 		fatal("read %d:", fd);
 	}
 	if (ret == 0) {
@@ -200,29 +220,29 @@ midiread(int fd)
 		 * the fd ourselves. Wrapper-inherited mode keeps the old
 		 * behavior of falling through (which would be a no-op read). */
 		if (self_opened_midi) {
-			dataend = data;
+			midireset();
 			return -1;
 		}
-		dataend = data;
+		midireset();
 		return 0;
 	}
-	dataend += ret;
-	datapos = data;
+	midibufend += ret;
+	datapos = midibuf;
 	for (;;) {
-		assert(datapos <= dataend);
-		datapos = memchr(datapos, 0xf0, dataend - datapos);
+		assert(datapos <= midibufend);
+		datapos = memchr(datapos, 0xf0, midibufend - datapos);
 		if (!datapos) {
-			dataend = data;
+			midireset();
 			break;
 		}
-		nextpos = memchr(datapos + 1, 0xf7, dataend - datapos - 1);
+		nextpos = memchr(datapos + 1, 0xf7, midibufend - datapos - 1);
 		if (!nextpos) {
-			if (dataend == data + sizeof data) {
+			if (midibufend == midibuf + sizeof midibuf) {
 				fprintf(stderr, "sysex packet too large; dropping\n");
-				dataend = data;
+				midireset();
 			} else {
-				memmove(data, datapos, dataend - datapos);
-				dataend -= datapos - data;
+				memmove(midibuf, datapos, midibufend - datapos);
+				midibufend -= datapos - midibuf;
 			}
 			break;
 		}
@@ -277,6 +297,21 @@ writeosc(const void *buf, size_t len)
 	ssize_t ret;
 
 	ret = write(wfd, buf, len);
+	if (ret < 0 && errno == ECONNREFUSED) {
+		/* On Linux, a connected UDP socket stores ICMP port
+		 * unreachable errors from previously-sent packets and
+		 * reports them on the next sendmsg(). The stored error
+		 * is cleared after it is reported, so retrying once is
+		 * sufficient: the previous packet is lost (nothing we
+		 * can do about that), but the current one needs to get
+		 * through. This matters at startup, when a frontend
+		 * like oscmix-gtk binds its recv socket slightly after
+		 * the backend has already sent its initial /device/id
+		 * bundle — without this retry, the backend's response
+		 * to the frontend's /refresh would hit the stored error
+		 * and the frontend would never leave its scanning page. */
+		ret = write(wfd, buf, len);
+	}
 	if (ret < 0) {
 		if (errno != ECONNREFUSED)
 			perror("write");
@@ -366,6 +401,16 @@ main(int argc, char *argv[])
 		}
 	}
 
+	/* Open OSC sockets before any potentially slow MIDI scan so that
+	 * frontends which start concurrently (e.g. oscmix-gtk launched right
+	 * after us) can send /refresh and have it buffered in the kernel
+	 * socket receive buffer rather than silently dropped. */
+	uint16_t recvport = sockaddrport(recvaddr);
+	uint16_t sendport = sockaddrport(sendaddr);
+
+	rfd = sockopen(recvaddr, 1);
+	wfd = sockopen(sendaddr, 0);
+
 	bool have_midi = (fcntl(6, F_GETFD) >= 0 && fcntl(7, F_GETFD) >= 0);
 
 	if (!have_midi) {
@@ -391,12 +436,6 @@ main(int argc, char *argv[])
 		usage(1);
 #endif
 	}
-
-	uint16_t recvport = sockaddrport(recvaddr);
-	uint16_t sendport = sockaddrport(sendaddr);
-
-	rfd = sockopen(recvaddr, 1);
-	wfd = sockopen(sendaddr, 0);
 
 	bool initialized = false;
 	if (have_midi) {
@@ -498,9 +537,13 @@ main(int argc, char *argv[])
 				/* Device went away. Transition to scanning state:
 				 * close the midi fds, tell frontends, and have the
 				 * poll loop stop reading midi until openmidi()
-				 * succeeds again. */
+				 * succeeds again. midireset() is already called
+				 * inside midiread() on the error path, but we do
+				 * it again here to be explicit about the state
+				 * reset at transition time. */
 				fprintf(stderr, "oscmix: midi device disconnected; "
 						"entering scanning state\n");
+				midireset();
 #ifdef __linux__
 				close_midi();
 #endif
@@ -525,18 +568,27 @@ main(int argc, char *argv[])
 			}
 		}
 
-		/* Control signal from coremidiio: 0x00=offline, 0x01=online */
+		/* Control signal from coremidiio: 0x00=offline, 0x01=online.
+		 * On macOS hotplug, coremidiio keeps the pipe on fds 6/7 open
+		 * across the disconnect, so midiread() never sees an error —
+		 * we only find out via this control channel. The SysEx
+		 * reassembly buffer must be reset here too because any
+		 * partial packet in flight at disconnect time would otherwise
+		 * be concatenated with fresh bytes from the reconnected
+		 * device and parsed as one corrupt packet. */
 		if (ctrl_fd >= 0 && (pfd[2].revents & POLLIN)) {
 			unsigned char sig;
 			if (read(ctrl_fd, &sig, 1) == 1) {
 				if (sig == 0x00 && online) {
 					fprintf(stderr, "oscmix: midi device disconnected\n");
+					midireset();
 					pfd[0].fd = -1;
 					online = false;
 					oscmix_announce_offline();
 					scan_tick = 0;
 				} else if (sig == 0x01 && !online) {
 					fprintf(stderr, "oscmix: midi device (re)connected\n");
+					midireset();
 					pfd[0].fd = 6;
 					online = true;
 					handleosc(refreshosc, sizeof refreshosc - 1);
@@ -561,7 +613,6 @@ main(int argc, char *argv[])
 					 * treating the absence as fatal. */
 					const char *usb_id = NULL;
 					if (usbscan_find(&usb_id)) {
-						static bool logged_race;
 						if (!logged_race) {
 							fprintf(stderr, "oscmix: detected "
 								"RME device (%s) via USB but "
@@ -591,6 +642,7 @@ main(int argc, char *argv[])
 						"(re)connected\n");
 					pfd[0].fd = 6;
 					online = true;
+					logged_race = false;
 					handleosc(refreshosc,
 						sizeof refreshosc - 1);
 				}

--- a/oscmix-gtk.sh
+++ b/oscmix-gtk.sh
@@ -3,11 +3,25 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Start the backend in the background if it's not already running
+# Kill any running oscmix that is using a stale (replaced) binary so the
+# freshly-built binary is always used.  Also kill if it was started from a
+# different location to avoid version mismatches.
+for pid in $(pgrep -x oscmix 2>/dev/null); do
+	exe=$(readlink /proc/$pid/exe 2>/dev/null)
+	# /proc/<pid>/exe ends with " (deleted)" when the on-disk binary has
+	# been replaced since the process started.
+	case "$exe" in
+		*" (deleted)") kill "$pid" 2>/dev/null ;;
+		"$SCRIPT_DIR/oscmix") ;;  # same binary, reuse it
+		*) kill "$pid" 2>/dev/null ;;  # different path, replace it
+	esac
+done
+
+# Start the backend if it is not already running (with our binary).
 if ! pgrep -x oscmix > /dev/null 2>&1; then
 	"$SCRIPT_DIR/oscmix" &
 	OSCMIX_PID=$!
 	trap 'kill $OSCMIX_PID 2>/dev/null' EXIT INT TERM
 fi
 
-GSETTINGS_SCHEMA_DIR="$SCRIPT_DIR/gtk" exec "$SCRIPT_DIR/gtk/oscmix-gtk" "$@"
+GSETTINGS_SCHEMA_DIR="$SCRIPT_DIR/gtk" "$SCRIPT_DIR/gtk/oscmix-gtk" "$@"

--- a/oscmix-gtk.sh
+++ b/oscmix-gtk.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Start the backend in the background if it's not already running
+if ! pgrep -x oscmix > /dev/null 2>&1; then
+	"$SCRIPT_DIR/oscmix" &
+	OSCMIX_PID=$!
+	trap 'kill $OSCMIX_PID 2>/dev/null' EXIT INT TERM
+fi
+
+GSETTINGS_SCHEMA_DIR="$SCRIPT_DIR/gtk" exec "$SCRIPT_DIR/gtk/oscmix-gtk" "$@"

--- a/oscmix.c
+++ b/oscmix.c
@@ -146,9 +146,8 @@ setreg(unsigned reg, unsigned val)
 	unsigned par;
 
 	val &= 0xffff;
-	if (dflag && reg != 0x3f00) fprintf(stderr, "setreg %.4X %.4X\n", reg, val);
-	// debug for webui
-	//if (reg != 0x3f00) fprintf(stderr, "WEBUI: setreg %.4X %.4X\n", reg, val);
+	if (dflag && reg != 0x3f00)
+		fprintf(stderr, "setreg %.4X %.4X\n", reg, val);
 	regval = (reg & 0x7fff) << 16 | val;
 	par = regval >> 16 ^ regval;
 	par ^= par >> 8;
@@ -547,7 +546,6 @@ setoutputloopback(struct context *ctx, struct oscmsg *msg)
 	unsigned char buf[4], sysexbuf[7 + 5];
 
 	val = oscgetint(msg);
-	fprintf(stderr, "setoutputloopback: val = %d, param.in = %d\n", val, ctx->param.in);
 	if (oscend(msg) != 0)
 		return;
 	putle32(buf, val << 7 | ctx->param.in);
@@ -1739,8 +1737,6 @@ oscsendenum(const char *addr, int val, const char *const names[], size_t namesle
 	if (val >= 0 && val < nameslen) {
 		oscsend(addr, ",is", val, names[val]);
 	} else {
-		fprintf(stderr, "unknown value for '%s': %d\n", addr, val);
-		fprintf(stderr, "nameslen=%zu\n", nameslen);
 		fprintf(stderr, "unexpected enum value %d\n", val);
 
 		oscsend(addr, ",i", val);

--- a/oscmix.c
+++ b/oscmix.c
@@ -1773,11 +1773,6 @@ handleregs(uint_least32_t *payload, size_t len)
 		reg = payload[i] >> 16 & 0x7fff;
 		val = (long)((payload[i] & 0xffff) ^ 0x8000) - 0x8000;
 
-		/* Debug: Print NAME range registers with their values */
-		if (reg >= 0x2800 && reg < 0x2C00) {
-			fprintf(stderr, "DEBUG handleregs: reg=0x%04X, val=0x%04X (%d)\n", reg, val & 0xFFFF, val);
-		}
-
 		ctx.param.in = ctx.param.out = -1;
 		ctx.reg = reg;  /* Store actual register number */
 		ctl = device->regtoctl(reg, &ctx.param);

--- a/oscmix.c
+++ b/oscmix.c
@@ -2032,3 +2032,11 @@ oscmix_getdevinfo(struct oscmix_devinfo *out)
 	out->inputs  = device ? device->inputslen : 0;
 	out->outputs = device ? device->outputslen : 0;
 }
+
+void
+oscmix_announce_offline(void)
+{
+	oscsend("/device/id",   ",s", "");
+	oscsend("/device/name", ",s", "");
+	oscflush();
+}

--- a/oscmix.h
+++ b/oscmix.h
@@ -22,4 +22,9 @@ struct oscmix_devinfo {
 
 void oscmix_getdevinfo(struct oscmix_devinfo *out);
 
+/* Broadcast empty /device/id + /device/name so frontends switch to
+ * their scanning / disconnected state. Called by main() when the
+ * midi fd read path fails with EIO/ENODEV. */
+void oscmix_announce_offline(void);
+
 #endif

--- a/spawn.c
+++ b/spawn.c
@@ -4,7 +4,7 @@
 #include "fatal.h"
 
 void
-spawn(const char *path, char *const argv[], int mode, int fd[2])
+spawn(const char *path, char *const argv[], int mode, int fd[2], int ctrlfd)
 {
 	pid_t pid;
 	int p[4], t[2];
@@ -42,6 +42,8 @@ spawn(const char *path, char *const argv[], int mode, int fd[2])
 		close(p[2]);
 		fd[0] = t[0];
 		fd[1] = t[1];
+		if (ctrlfd >= 0)
+			close(ctrlfd);
 	} else {
 		if (p[0] != -1 && p[0] != p[1]) {
 			if (dup2(p[0], p[1]) < 0)
@@ -52,6 +54,11 @@ spawn(const char *path, char *const argv[], int mode, int fd[2])
 			if (dup2(p[2], p[3]) < 0)
 				fatal("dup2:");
 			close(p[2]);
+		}
+		if (ctrlfd >= 0 && ctrlfd != 8) {
+			if (dup2(ctrlfd, 8) < 0)
+				fatal("dup2 ctrlfd:");
+			close(ctrlfd);
 		}
 		execvp(argv[0], argv);
 		fatal("exec %s:", argv[0]);

--- a/spawn.h
+++ b/spawn.h
@@ -6,6 +6,8 @@ enum {
 	WRITE = 2,
 };
 
-void spawn(const char *path, char *const argv[], int mode, int fd[2]);
+/* ctrlfd: if >= 0, dup2'd to fd 8 in the exec'd child so the child can
+ * receive control signals; closed on the fork-continued (coremidiio) side. */
+void spawn(const char *path, char *const argv[], int mode, int fd[2], int ctrlfd);
 
 #endif

--- a/usbscan.c
+++ b/usbscan.c
@@ -15,14 +15,29 @@ struct usb_id {
 	const char *oscmix_id;
 };
 
-/* Known RME vid/pid pairs. Incomplete: only values verified by
- * contributors are listed; others default to the ALSA card-name scan.
- * Extend as real hardware lets us confirm each pair in CC-mode and
- * USB-mode. */
+/* Known RME vid/pid pairs in class-compliant (CC) mode.
+ *
+ * Sources:
+ *   UCX     — Vasco Santos, huddx01/oscmix#13 (lsusb in CC mode)
+ *   UCX II  — confirmed on local hardware (lsusb 2a39:3fd9)
+ *   802     — sjzstudio, RME Linux forum thread (lsusb in CC mode)
+ *   UFX III — Floodswood, michaelforney/oscmix#19 (USB descriptor dump)
+ *   UFX II  — laex333, michaelforney/oscmix#7 (lsusb in CC mode)
+ *   UFX+    — Sojuzstudio, michaelforney/oscmix#5 (lsusb; CC mode assumed)
+ *
+ * NOTE: UFX II and UFX+ share vid:pid 2a39:3fd1 — they cannot be
+ * distinguished by USB id alone. The ALSA card-name scan in main.c
+ * is the authoritative detection path; this table is only used as a
+ * hint to log "device present but driver not yet bound" during reconnect.
+ *
+ * UCX/802 enumerate under Microchip's VID (0424) in CC mode.
+ * UCX II, UFX+/II, UFX III enumerate under RME's own VID (2a39). */
 static const struct usb_id known[] = {
-	/* Vasco Santos reported this pair for a Fireface UCX via lsusb
-	 * in huddx01/oscmix issue #13. */
-	{ 0x0424, 0x3fb9, "ffucx" },
+	{ 0x0424, 0x3fb9, "ffucx"   },  /* Fireface UCX      */
+	{ 0x2a39, 0x3fd9, "ffucxii" },  /* Fireface UCX II   */
+	{ 0x0424, 0x3fdd, "ff802"   },  /* Fireface 802      */
+	{ 0x2a39, 0x3fde, "ffufxiii"},  /* Fireface UFX III  */
+	{ 0x2a39, 0x3fd1, "ffufxii" },  /* Fireface UFX II / UFX+ (shared pid) */
 };
 
 static int

--- a/usbscan.c
+++ b/usbscan.c
@@ -1,0 +1,98 @@
+#define _POSIX_C_SOURCE 200809L
+#include "usbscan.h"
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+struct usb_id {
+	uint16_t vid;
+	uint16_t pid;
+	const char *oscmix_id;
+};
+
+/* Known RME vid/pid pairs. Incomplete: only values verified by
+ * contributors are listed; others default to the ALSA card-name scan.
+ * Extend as real hardware lets us confirm each pair in CC-mode and
+ * USB-mode. */
+static const struct usb_id known[] = {
+	/* Vasco Santos reported this pair for a Fireface UCX via lsusb
+	 * in huddx01/oscmix issue #13. */
+	{ 0x0424, 0x3fb9, "ffucx" },
+};
+
+static int
+read_hex4(const char *path, uint16_t *out)
+{
+	int fd, ret;
+	char buf[8];
+	unsigned long val;
+
+	fd = open(path, O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
+		return -1;
+	ret = read(fd, buf, sizeof buf - 1);
+	close(fd);
+	if (ret <= 0)
+		return -1;
+	buf[ret] = '\0';
+	val = strtoul(buf, NULL, 16);
+	if (val > 0xffff)
+		return -1;
+	*out = (uint16_t)val;
+	return 0;
+}
+
+bool
+usbscan_find(const char **out_id)
+{
+	DIR *dir;
+	struct dirent *ent;
+	char path[256];
+	uint16_t vid, pid;
+	size_t i;
+
+	dir = opendir("/sys/bus/usb/devices");
+	if (!dir)
+		return false;
+
+	while ((ent = readdir(dir)) != NULL) {
+		if (ent->d_name[0] == '.')
+			continue;
+		/* Skip "usbN" root hubs — they never carry a real vid/pid
+		 * we care about. Real devices have names like "1-1" or
+		 * "1-1.2". */
+		if (ent->d_name[0] == 'u' && ent->d_name[1] == 's'
+				&& ent->d_name[2] == 'b')
+			continue;
+		/* Skip interface nodes ("1-1:1.0") — we only want the
+		 * per-device directory. */
+		if (strchr(ent->d_name, ':'))
+			continue;
+
+		snprintf(path, sizeof path, "/sys/bus/usb/devices/%s/idVendor",
+				ent->d_name);
+		if (read_hex4(path, &vid) != 0)
+			continue;
+		snprintf(path, sizeof path, "/sys/bus/usb/devices/%s/idProduct",
+				ent->d_name);
+		if (read_hex4(path, &pid) != 0)
+			continue;
+
+		for (i = 0; i < sizeof known / sizeof known[0]; ++i) {
+			if (known[i].vid == vid && known[i].pid == pid) {
+				if (out_id)
+					*out_id = known[i].oscmix_id;
+				closedir(dir);
+				return true;
+			}
+		}
+	}
+
+	closedir(dir);
+	return false;
+}

--- a/usbscan.h
+++ b/usbscan.h
@@ -1,0 +1,19 @@
+#ifndef OSCMIX_USBSCAN_H
+#define OSCMIX_USBSCAN_H
+
+#include <stdbool.h>
+
+/* Diagnostic USB scan: walks /sys/bus/usb/devices/*\/{idVendor,idProduct}
+ * and reports whether a supported RME device is plugged in, even if the
+ * ALSA midi subsystem has not yet claimed it. The primary detection path
+ * remains the ALSA card scan in main.c:openmidi() — this is only a hint
+ * used to distinguish "no hardware" from "driver race" during the
+ * reconnect loop.
+ *
+ * Returns true and writes the matched oscmix device id (e.g. "ffucx")
+ * to *out_id when a known vid/pid pair is present in sysfs. Returns
+ * false otherwise. The pointer returned in *out_id has static lifetime.
+ */
+bool usbscan_find(const char **out_id);
+
+#endif


### PR DESCRIPTION
## Summary

- **Backend (`main.c`)**: port `openmidi()` to scan `/dev/snd/controlC*` for any supported RME card, keep the daemon alive through `EIO`/`ENODEV` on the MIDI fds, and retry on a 1 s cadence while offline. On every online/offline transition emit `/device/id` + `/device/name` (empty string = offline) so frontends can react without polling. Lift the SysEx reassembly buffer to file scope with `midireset()` so stale partial packets are cleared on disconnect. Fix `openmidi()` to use `break` instead of `return -1` on inner failures so a bad card doesn't abort the whole scan. Add ECONNREFUSED retry in `writeosc()` to handle the Linux stored-ICMP race that left the GTK frontend stuck on the scanning page at startup.

- **USB sysfs scanner (`usbscan.c/h`)**: scan `/sys/bus/usb/devices` to distinguish "device unplugged" from "snd-usb-audio hasn't bound yet" during fast reconnects. Covers UCX II, 802, UFX III, UFX II/UFX+.

- **GTK UI (`gtk/main.c`, `gtk/oscmix.ui`)**: replace the modal offline dialog with a `GtkStack` "scanning" / "mixer" pair driven by `/device/id`. `clear_device()` tears down stale channel widgets before each rebuild so reconnect cycles don't leak. Guard `on_mainout_osc` against NULL `outputs_model`.

- **macOS (`coremidiio.c`)**: keep coremidiio running across device removal/re-addition using CoreMIDI `kMIDIMsgObjectRemoved`/`kMIDIMsgObjectAdded` notifications. Fix reconnect matching when `-p` is not passed (virtual port mode). Zero-initialise `ctx[2]` to prevent spurious disconnect on early hotplug notification.

- **Linux POLLHUP/POLLERR (`main.c`)**: detect USB disconnect via `POLLHUP`/`POLLERR` on the raw MIDI fd when oscmix owns it; scope the check to `self_opened_midi` to avoid false positives in wrapper mode.

- **`oscmix-gtk.sh`**: kill stale (rebuilt-since-start) backend processes before launching so the freshly built binary is always used. Drop `exec` so the EXIT trap fires when the GTK window closes, killing the backend.

Fixes #13.

## Test plan

- [ ] Start oscmix-gtk.sh with device connected — mixer page appears immediately (no spinner hang)
- [ ] Start oscmix-gtk.sh with device disconnected — spinner shown, mixer appears when device is plugged in
- [ ] Unplug device mid-session — scanning page returns; replug — mixer returns without restarting
- [ ] Kill and rebuild oscmix while GTK is open — re-running oscmix-gtk.sh picks up the new binary
- [ ] Close GTK window — oscmix backend process exits
- [ ] macOS: unplug/replug Fireface — coremidiio reconnects without restart