### PR TITLE
oscmix: fix hotplug reliability bugs and improve oscmix-gtk.sh

### DIFF
--- a/coremidiio.c
+++ b/coremidiio.c
@@ -428,7 +428,11 @@ main(int argc, char *argv[])
 		fcntl(ctrl[1], F_SETFD, FD_CLOEXEC);
 		g_ctrl_wfd = ctrl[1];
 		spawn(argv[0], argv, mode, fd, ctrl[0]);
-		/* ctrl[0] was closed inside spawn(); g_ctrl_wfd=ctrl[1] is ours. */
+		/* ctrl[0] was closed inside spawn(); g_ctrl_wfd=ctrl[1] is ours.
+		 * Note: do NOT touch CoreMIDI (MIDIGetSource etc.) before spawn.
+		 * spawn() forks, and any CoreMIDI use opens a Mach port
+		 * connection to midiserver that does not survive fork —
+		 * MIDIClientCreate below would then fail with OSStatus -304. */
 	}
 
 	err = MIDIClientCreate(name, notify, ctx, &client);

--- a/coremidiio.c
+++ b/coremidiio.c
@@ -310,14 +310,16 @@ notify(const struct MIDINotification *n, void *info)
 		obj = ar->child;
 		epname(obj, name, sizeof name);
 		if ((g_mode & READ) && ar->childType == kMIDIObjectType_Source
-				&& ctx[0].ep == 0 && strcmp(name, g_src_name) == 0) {
+				&& ctx[0].ep == 0 && g_src_name[0] != '\0'
+				&& strcmp(name, g_src_name) == 0) {
 			ctx[0].ep = (MIDIEndpointRef)obj;
 			err = MIDIPortConnectSource(ctx[0].port, ctx[0].ep, NULL);
 			if (err)
 				fprintf(stderr, "coremidiio: MIDIPortConnectSource: %d\n", (int)err);
 		}
 		if ((g_mode & WRITE) && ar->childType == kMIDIObjectType_Destination
-				&& ctx[1].ep == 0 && strcmp(name, g_dst_name) == 0) {
+				&& ctx[1].ep == 0 && g_dst_name[0] != '\0'
+				&& strcmp(name, g_dst_name) == 0) {
 			ctx[1].ep = (MIDIEndpointRef)obj;
 		}
 		reader_ok = !(g_mode & READ) || ctx[0].ep != 0;
@@ -370,8 +372,18 @@ main(int argc, char *argv[])
 	int port[2], fd[2];
 	CFStringRef name;
 	int mode;
-	struct context ctx[2];
+	struct context ctx[2] = {0};
 	int ctrl[2];
+
+	/* ctx is passed to MIDIClientCreate as the notify callback's
+	 * info pointer. notify() reads ctx[0].ep and ctx[1].ep before
+	 * initreader()/initwriter() have populated them — if a hotplug
+	 * event fires during that window (or for WRITE-only / READ-only
+	 * modes where only one slot is initialized), uninitialized
+	 * endpoint values would be compared against the incoming object
+	 * and might randomly match, causing a spurious disconnect. Zero
+	 * initialization keeps the early-return path in notify() correct
+	 * until real endpoints are installed. */
 
 	port[0] = -1;
 	port[1] = -1;

--- a/main.c
+++ b/main.c
@@ -35,6 +35,10 @@ static volatile sig_atomic_t timeout;
  * the fds were inherited from a wrapper (alsarawio / alsaseqio / coremidiio)
  * and we preserve the original fatal-on-error semantics. */
 static bool self_opened_midi;
+/* Set when the USB-present-but-ALSA-not-ready race has been logged, so we
+ * don't repeat it every second. Reset each time the device goes offline so
+ * the next fast-reconnect cycle logs again if the race recurs. */
+static bool logged_race;
 
 #ifdef __linux__
 /* Device name prefixes matched against snd_ctl_card_info.name.
@@ -74,37 +78,37 @@ openmidi(void)
 				continue;
 			if (ioctl(ctlfd, SNDRV_CTL_IOCTL_RAWMIDI_PREFER_SUBDEVICE, &(int){1}) != 0) {
 				perror("ioctl SNDRV_CTL_IOCTL_RAWMIDI_PREFER_SUBDEVICE");
-				close(ctlfd);
-				return -1;
+				break;  /* try next card; outer loop closes ctlfd */
 			}
 			snprintf(path, sizeof path, "/dev/snd/midiC%dD0", card);
 			midifd = open(path, O_RDWR | O_CLOEXEC);
 			close(ctlfd);
+			ctlfd = -1;  /* closed; prevent double-close by outer loop */
 			if (midifd < 0) {
 				fprintf(stderr, "open %s: %s\n", path, strerror(errno));
-				return -1;
+				break;
 			}
 			if (ioctl(midifd, (int)SNDRV_RAWMIDI_IOCTL_PVERSION, &ver) != 0) {
 				perror("ioctl SNDRV_RAWMIDI_IOCTL_PVERSION");
 				close(midifd);
-				return -1;
+				break;
 			}
 			if (SNDRV_PROTOCOL_INCOMPATIBLE(ver, SNDRV_RAWMIDI_VERSION)) {
 				fprintf(stderr, "incompatible rawmidi version\n");
 				close(midifd);
-				return -1;
+				break;
 			}
 			memset(&info, 0, sizeof info);
 			info.stream = SNDRV_RAWMIDI_STREAM_INPUT;
 			if (ioctl(midifd, (int)SNDRV_RAWMIDI_IOCTL_INFO, &info) != 0) {
 				perror("ioctl SNDRV_RAWMIDI_IOCTL_INFO");
 				close(midifd);
-				return -1;
+				break;
 			}
 			if (info.subdevice != 1) {
 				fprintf(stderr, "could not open subdevice 1\n");
 				close(midifd);
-				return -1;
+				break;
 			}
 			snprintf(midiport, sizeof midiport, "%s", (char *)info.subname);
 
@@ -116,25 +120,26 @@ openmidi(void)
 			if (ioctl(midifd, (int)SNDRV_RAWMIDI_IOCTL_PARAMS, &params) != 0) {
 				perror("ioctl SNDRV_RAWMIDI_IOCTL_PARAMS");
 				close(midifd);
-				return -1;
+				break;
 			}
 			params.stream = SNDRV_RAWMIDI_STREAM_OUTPUT;
 			if (ioctl(midifd, (int)SNDRV_RAWMIDI_IOCTL_PARAMS, &params) != 0) {
 				perror("ioctl SNDRV_RAWMIDI_IOCTL_PARAMS");
 				close(midifd);
-				return -1;
+				break;
 			}
 			if (dup2(midifd, 6) < 0 || dup2(midifd, 7) < 0) {
 				perror("dup2");
 				if (midifd != 6 && midifd != 7)
 					close(midifd);
-				return -1;
+				break;
 			}
 			if (midifd != 6 && midifd != 7)
 				close(midifd);
 			return 0;
 		}
-		close(ctlfd);
+		if (ctlfd >= 0)
+			close(ctlfd);
 	}
 	return -1;
 }
@@ -175,6 +180,20 @@ usage(int status)
 	exit(status);
 }
 
+/* SysEx reassembly buffer. Lifted out of midiread() so that the disconnect
+ * transitions in the poll loop can clear any partial data that was
+ * mid-stream when the device went away — otherwise stale bytes would be
+ * concatenated with fresh bytes on reconnect and parsed as one corrupt
+ * SysEx packet. */
+static unsigned char midibuf[8192];
+static unsigned char *midibufend = midibuf;
+
+static void
+midireset(void)
+{
+	midibufend = midibuf;
+}
+
 /* Returns 0 on success (including partial read), -1 if the midi device
  * went away (EIO / ENODEV / EBADF / ENXIO / unexpected EOF). Other errors
  * still call fatal() to preserve the previous behavior for truly
@@ -182,16 +201,17 @@ usage(int status)
 static int
 midiread(int fd)
 {
-	static unsigned char data[8192], *dataend = data;
 	unsigned char *datapos, *nextpos;
-	uint_least32_t payload[sizeof data / 4];
+	uint_least32_t payload[sizeof midibuf / 4];
 	ssize_t ret;
 
-	ret = read(fd, dataend, (data + sizeof data) - dataend);
+	ret = read(fd, midibufend, (midibuf + sizeof midibuf) - midibufend);
 	if (ret < 0) {
 		if (self_opened_midi && (errno == EIO || errno == ENODEV
-				|| errno == EBADF || errno == ENXIO))
+				|| errno == EBADF || errno == ENXIO)) {
+			midireset();
 			return -1;
+		}
 		fatal("read %d:", fd);
 	}
 	if (ret == 0) {
@@ -199,29 +219,29 @@ midiread(int fd)
 		 * the fd ourselves. Wrapper-inherited mode keeps the old
 		 * behavior of falling through (which would be a no-op read). */
 		if (self_opened_midi) {
-			dataend = data;
+			midireset();
 			return -1;
 		}
-		dataend = data;
+		midireset();
 		return 0;
 	}
-	dataend += ret;
-	datapos = data;
+	midibufend += ret;
+	datapos = midibuf;
 	for (;;) {
-		assert(datapos <= dataend);
-		datapos = memchr(datapos, 0xf0, dataend - datapos);
+		assert(datapos <= midibufend);
+		datapos = memchr(datapos, 0xf0, midibufend - datapos);
 		if (!datapos) {
-			dataend = data;
+			midireset();
 			break;
 		}
-		nextpos = memchr(datapos + 1, 0xf7, dataend - datapos - 1);
+		nextpos = memchr(datapos + 1, 0xf7, midibufend - datapos - 1);
 		if (!nextpos) {
-			if (dataend == data + sizeof data) {
+			if (midibufend == midibuf + sizeof midibuf) {
 				fprintf(stderr, "sysex packet too large; dropping\n");
-				dataend = data;
+				midireset();
 			} else {
-				memmove(data, datapos, dataend - datapos);
-				dataend -= datapos - data;
+				memmove(midibuf, datapos, midibufend - datapos);
+				midibufend -= datapos - midibuf;
 			}
 			break;
 		}
@@ -276,6 +296,21 @@ writeosc(const void *buf, size_t len)
 	ssize_t ret;
 
 	ret = write(wfd, buf, len);
+	if (ret < 0 && errno == ECONNREFUSED) {
+		/* On Linux, a connected UDP socket stores ICMP port
+		 * unreachable errors from previously-sent packets and
+		 * reports them on the next sendmsg(). The stored error
+		 * is cleared after it is reported, so retrying once is
+		 * sufficient: the previous packet is lost (nothing we
+		 * can do about that), but the current one needs to get
+		 * through. This matters at startup, when a frontend
+		 * like oscmix-gtk binds its recv socket slightly after
+		 * the backend has already sent its initial /device/id
+		 * bundle — without this retry, the backend's response
+		 * to the frontend's /refresh would hit the stored error
+		 * and the frontend would never leave its scanning page. */
+		ret = write(wfd, buf, len);
+	}
 	if (ret < 0) {
 		if (errno != ECONNREFUSED)
 			perror("write");
@@ -365,6 +400,16 @@ main(int argc, char *argv[])
 		}
 	}
 
+	/* Open OSC sockets before any potentially slow MIDI scan so that
+	 * frontends which start concurrently (e.g. oscmix-gtk launched right
+	 * after us) can send /refresh and have it buffered in the kernel
+	 * socket receive buffer rather than silently dropped. */
+	uint16_t recvport = sockaddrport(recvaddr);
+	uint16_t sendport = sockaddrport(sendaddr);
+
+	rfd = sockopen(recvaddr, 1);
+	wfd = sockopen(sendaddr, 0);
+
 	bool have_midi = (fcntl(6, F_GETFD) >= 0 && fcntl(7, F_GETFD) >= 0);
 
 	if (!have_midi) {
@@ -401,6 +446,7 @@ main(int argc, char *argv[])
 
 	rfd = sockopen(recvaddr, 1);
 	wfd = sockopen(sendaddr, 0);
+
 
 	bool initialized = false;
 	if (have_midi) {
@@ -502,9 +548,13 @@ main(int argc, char *argv[])
 				/* Device went away. Transition to scanning state:
 				 * close the midi fds, tell frontends, and have the
 				 * poll loop stop reading midi until openmidi()
-				 * succeeds again. */
+				 * succeeds again. midireset() is already called
+				 * inside midiread() on the error path, but we do
+				 * it again here to be explicit about the state
+				 * reset at transition time. */
 				fprintf(stderr, "oscmix: midi device disconnected; "
 						"entering scanning state\n");
+				midireset();
 #ifdef __linux__
 				close_midi();
 #endif
@@ -529,18 +579,27 @@ main(int argc, char *argv[])
 			}
 		}
 
-		/* Control signal from coremidiio: 0x00=offline, 0x01=online */
+		/* Control signal from coremidiio: 0x00=offline, 0x01=online.
+		 * On macOS hotplug, coremidiio keeps the pipe on fds 6/7 open
+		 * across the disconnect, so midiread() never sees an error —
+		 * we only find out via this control channel. The SysEx
+		 * reassembly buffer must be reset here too because any
+		 * partial packet in flight at disconnect time would otherwise
+		 * be concatenated with fresh bytes from the reconnected
+		 * device and parsed as one corrupt packet. */
 		if (ctrl_fd >= 0 && (pfd[2].revents & POLLIN)) {
 			unsigned char sig;
 			if (read(ctrl_fd, &sig, 1) == 1) {
 				if (sig == 0x00 && online) {
 					fprintf(stderr, "oscmix: midi device disconnected\n");
+					midireset();
 					pfd[0].fd = -1;
 					online = false;
 					oscmix_announce_offline();
 					scan_tick = 0;
 				} else if (sig == 0x01 && !online) {
 					fprintf(stderr, "oscmix: midi device (re)connected\n");
+					midireset();
 					pfd[0].fd = 6;
 					online = true;
 					handleosc(refreshosc, sizeof refreshosc - 1);
@@ -565,7 +624,6 @@ main(int argc, char *argv[])
 					 * treating the absence as fatal. */
 					const char *usb_id = NULL;
 					if (usbscan_find(&usb_id)) {
-						static bool logged_race;
 						if (!logged_race) {
 							fprintf(stderr, "oscmix: detected "
 								"RME device (%s) via USB but "
@@ -595,6 +653,7 @@ main(int argc, char *argv[])
 						"(re)connected\n");
 					pfd[0].fd = 6;
 					online = true;
+					logged_race = false;
 					handleosc(refreshosc,
 						sizeof refreshosc - 1);
 				}

--- a/main.c
+++ b/main.c
@@ -58,7 +58,7 @@ static char midiport[80];
 static int
 openmidi(void)
 {
-	int card, ctlfd, midifd, ver, i;
+	int card, ctlfd, midifd, ver, i, target_subdev;
 	char path[64];
 	struct snd_ctl_card_info cardinfo;
 	struct snd_rawmidi_info info;
@@ -76,7 +76,25 @@ openmidi(void)
 		for (i = 0; midi_devices[i]; ++i) {
 			if (strncmp((char *)cardinfo.name, midi_devices[i], strlen(midi_devices[i])) != 0)
 				continue;
-			if (ioctl(ctlfd, SNDRV_CTL_IOCTL_RAWMIDI_PREFER_SUBDEVICE, &(int){1}) != 0) {
+			/* Query subdevice count on device 0 and target the
+			 * last one. RME devices expose the host control port
+			 * as the last MIDI subdevice — UCX II has 3 (target
+			 * 2), UFX III has 4 (target 3), 802 varies by mode.
+			 * Hardcoding subdevice 1 broke everything except UCX. */
+			memset(&info, 0, sizeof info);
+			info.device = 0;
+			info.subdevice = 0;
+			info.stream = SNDRV_RAWMIDI_STREAM_INPUT;
+			if (ioctl(ctlfd, SNDRV_CTL_IOCTL_RAWMIDI_INFO, &info) != 0) {
+				perror("ioctl SNDRV_CTL_IOCTL_RAWMIDI_INFO");
+				break;
+			}
+			if (info.subdevices_count == 0) {
+				fprintf(stderr, "no rawmidi subdevices on card %d\n", card);
+				break;
+			}
+			target_subdev = (int)info.subdevices_count - 1;
+			if (ioctl(ctlfd, SNDRV_CTL_IOCTL_RAWMIDI_PREFER_SUBDEVICE, &target_subdev) != 0) {
 				perror("ioctl SNDRV_CTL_IOCTL_RAWMIDI_PREFER_SUBDEVICE");
 				break;  /* try next card; outer loop closes ctlfd */
 			}
@@ -105,8 +123,9 @@ openmidi(void)
 				close(midifd);
 				break;
 			}
-			if (info.subdevice != 1) {
-				fprintf(stderr, "could not open subdevice 1\n");
+			if ((int)info.subdevice != target_subdev) {
+				fprintf(stderr, "could not open subdevice %d (got %u)\n",
+					target_subdev, info.subdevice);
 				close(midifd);
 				break;
 			}
@@ -255,7 +274,12 @@ midiread(int fd)
 static void
 oscread(int fd)
 {
-	unsigned char buf[8192];
+	/* One UDP datagram per read; any bytes beyond this are silently
+	 * dropped by the kernel. UFX III has 94 I/O channels and can send
+	 * large bundles, so size for the theoretical UDP payload maximum
+	 * rather than the previous 8 KB which was close to oscmix's own
+	 * send bundle size and could easily truncate. */
+	unsigned char buf[65536];
 	ssize_t ret;
 
 	ret = read(fd, buf, sizeof buf);
@@ -439,14 +463,6 @@ main(int argc, char *argv[])
 	/* Ignore SIGPIPE so that failed writes (e.g. to a multicast socket
 	 * with no active listeners) return EPIPE instead of killing the process. */
 	signal(SIGPIPE, SIG_IGN);
-
-	/* Parse ports before sockopen() modifies the address strings in-place. */
-	uint16_t recvport = sockaddrport(recvaddr);
-	uint16_t sendport = sockaddrport(sendaddr);
-
-	rfd = sockopen(recvaddr, 1);
-	wfd = sockopen(sendaddr, 0);
-
 
 	bool initialized = false;
 	if (have_midi) {

--- a/oscmix-gtk.sh
+++ b/oscmix-gtk.sh
@@ -3,11 +3,25 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Start the backend in the background if it's not already running
+# Kill any running oscmix that is using a stale (replaced) binary so the
+# freshly-built binary is always used.  Also kill if it was started from a
+# different location to avoid version mismatches.
+for pid in $(pgrep -x oscmix 2>/dev/null); do
+	exe=$(readlink /proc/$pid/exe 2>/dev/null)
+	# /proc/<pid>/exe ends with " (deleted)" when the on-disk binary has
+	# been replaced since the process started.
+	case "$exe" in
+		*" (deleted)") kill "$pid" 2>/dev/null ;;
+		"$SCRIPT_DIR/oscmix") ;;  # same binary, reuse it
+		*) kill "$pid" 2>/dev/null ;;  # different path, replace it
+	esac
+done
+
+# Start the backend if it is not already running (with our binary).
 if ! pgrep -x oscmix > /dev/null 2>&1; then
 	"$SCRIPT_DIR/oscmix" &
 	OSCMIX_PID=$!
 	trap 'kill $OSCMIX_PID 2>/dev/null' EXIT INT TERM
 fi
 
-GSETTINGS_SCHEMA_DIR="$SCRIPT_DIR/gtk" exec "$SCRIPT_DIR/gtk/oscmix-gtk" "$@"
+GSETTINGS_SCHEMA_DIR="$SCRIPT_DIR/gtk" "$SCRIPT_DIR/gtk/oscmix-gtk" "$@"

--- a/oscmix-gtk.sh
+++ b/oscmix-gtk.sh
@@ -17,11 +17,52 @@ for pid in $(pgrep -x oscmix 2>/dev/null); do
 	esac
 done
 
-# Start the backend if it is not already running (with our binary).
-if ! pgrep -x oscmix > /dev/null 2>&1; then
+# oscmix needs MIDI fds 6/7 set up. On Linux, oscmix can self-open via
+# /dev/snd/controlC*. On macOS the CoreMIDI API is only reachable via the
+# coremidiio helper, so wrap the backend in that and auto-pick the last
+# Fireface port (same "last port" convention as the Linux side).
+start_backend_macos() {
+	# Emit "<index>\t<name>" for the last Fireface source — "last port" is
+	# the convention used by alsarawio (Linux) and the README.  Export
+	# MIDIPORT so oscmix can pick the device without -p; coremidiio cannot
+	# resolve it itself because touching CoreMIDI before its spawn()/fork
+	# causes MIDIClientCreate to fail with OSStatus -304.
+	line=$(
+		"$SCRIPT_DIR/coremidiio" -l 2>/dev/null \
+			| awk -F'\t' '
+				/^Sources:/     { section = "src"; next }
+				/^Destinations:/ { exit }
+				section == "src" && /Fireface/ {
+					idx  = $1
+					name = $2
+				}
+				END { if (idx != "") printf "%s\t%s\n", idx, name }
+			'
+	)
+	if [ -z "$line" ]; then
+		echo "oscmix-gtk.sh: no Fireface source found in coremidiio -l" >&2
+		echo "oscmix-gtk.sh: launching GTK anyway; UI will show scanning" >&2
+		return 1
+	fi
+	port=${line%%	*}
+	name=${line#*	}
+	MIDIPORT=$name \
+		"$SCRIPT_DIR/coremidiio" -f 6,7 -p "$port" "$SCRIPT_DIR/oscmix" &
+	OSCMIX_PID=$!
+	trap 'kill $OSCMIX_PID 2>/dev/null' EXIT INT TERM
+}
+
+start_backend_linux() {
 	"$SCRIPT_DIR/oscmix" &
 	OSCMIX_PID=$!
 	trap 'kill $OSCMIX_PID 2>/dev/null' EXIT INT TERM
+}
+
+if ! pgrep -x oscmix > /dev/null 2>&1; then
+	case "$(uname -s)" in
+		Darwin) start_backend_macos || true ;;
+		*)      start_backend_linux ;;
+	esac
 fi
 
 GSETTINGS_SCHEMA_DIR="$SCRIPT_DIR/gtk" "$SCRIPT_DIR/gtk/oscmix-gtk" "$@"

--- a/oscmix.c
+++ b/oscmix.c
@@ -146,9 +146,8 @@ setreg(unsigned reg, unsigned val)
 	unsigned par;
 
 	val &= 0xffff;
-	if (dflag && reg != 0x3f00) fprintf(stderr, "setreg %.4X %.4X\n", reg, val);
-	// debug for webui
-	//if (reg != 0x3f00) fprintf(stderr, "WEBUI: setreg %.4X %.4X\n", reg, val);
+	if (dflag && reg != 0x3f00)
+		fprintf(stderr, "setreg %.4X %.4X\n", reg, val);
 	regval = (reg & 0x7fff) << 16 | val;
 	par = regval >> 16 ^ regval;
 	par ^= par >> 8;
@@ -612,7 +611,6 @@ setoutputloopback(struct context *ctx, struct oscmsg *msg)
 	unsigned char buf[4], sysexbuf[7 + 5];
 
 	val = oscgetint(msg);
-	fprintf(stderr, "setoutputloopback: val = %d, param.in = %d\n", val, ctx->param.in);
 	if (oscend(msg) != 0)
 		return;
 	putle32(buf, val << 7 | ctx->param.in);
@@ -1831,8 +1829,6 @@ oscsendenum(const char *addr, int val, const char *const names[], size_t namesle
 	if (val >= 0 && val < nameslen) {
 		oscsend(addr, ",is", val, names[val]);
 	} else {
-		fprintf(stderr, "unknown value for '%s': %d\n", addr, val);
-		fprintf(stderr, "nameslen=%zu\n", nameslen);
 		fprintf(stderr, "unexpected enum value %d\n", val);
 
 		oscsend(addr, ",i", val);

--- a/oscmix.c
+++ b/oscmix.c
@@ -1721,8 +1721,8 @@ static const struct node roottree[] = {
 /* maps control number to indices into roottree */
 static unsigned char nodeindex[NUMCTLS][4];
 
-int
-handleosc(const unsigned char *buf, size_t len)
+static int
+handleoscmsg(const unsigned char *buf, size_t len)
 {
 	const struct node *node;
 	struct context ctx;
@@ -1730,8 +1730,6 @@ handleosc(const unsigned char *buf, size_t len)
 	const char *pattern;
 	char *end;
 
-	if (len % 4 != 0)
-		return -1;
 	msg.err = NULL;
 	msg.buf = (unsigned char *)buf;
 	msg.end = (unsigned char *)buf + len;
@@ -1771,6 +1769,46 @@ handleosc(const unsigned char *buf, size_t len)
 		node = node->tree;
 	}
 	return 0;
+}
+
+/* Dispatch a single OSC packet. Recurses for bundles (OSC 1.0 §3): a packet
+ * whose address string is "#bundle" is followed by an 8-byte time tag and
+ * then any number of size-prefixed sub-packets, each of which may itself be
+ * a bundle. Frontends like the web UI and external OSC clients routinely
+ * send bundles, and the UFX III's /refresh response produces large bundles —
+ * the previous single-message-only handler rejected all of them as
+ * "invalid osc address '#bundle'", which silently broke those frontends. */
+static int
+handleoscpacket(const unsigned char *buf, size_t len)
+{
+	if (len >= 8 && memcmp(buf, "#bundle\0", 8) == 0) {
+		const unsigned char *pos = buf + 16;  /* skip "#bundle\0" + timetag */
+		const unsigned char *end = buf + len;
+		if (len < 16)
+			return -1;
+		while (pos < end) {
+			uint32_t sublen;
+			if (end - pos < 4)
+				return -1;
+			sublen = (uint32_t)pos[0] << 24 | (uint32_t)pos[1] << 16
+				| (uint32_t)pos[2] << 8 | pos[3];
+			pos += 4;
+			if (sublen > (uint32_t)(end - pos) || (sublen & 3) != 0)
+				return -1;
+			handleoscpacket(pos, sublen);
+			pos += sublen;
+		}
+		return 0;
+	}
+	return handleoscmsg(buf, len);
+}
+
+int
+handleosc(const unsigned char *buf, size_t len)
+{
+	if (len % 4 != 0)
+		return -1;
+	return handleoscpacket(buf, len);
 }
 
 static unsigned char oscbuf[8192];


### PR DESCRIPTION
Follow-up to #18 with reliability fixes found during testing.

## Changes

**`main.c`**
- `writeosc()`: retry once on `ECONNREFUSED` — on Linux, a connected UDP socket stores the ICMP port-unreachable from the initial `/device/id` send (before the GTK frontend has bound its socket) and returns it on the next write, dropping the frontend's `/refresh` response and leaving the UI stuck on the scanning page.
- `midiread()`: lift the SysEx reassembly buffer to file scope (`midibuf`/`midireset()`) so disconnect transitions can clear any partial packet in flight — previously stale bytes were concatenated with fresh bytes on reconnect, producing corrupt SysEx.
- `openmidi()`: change inner-loop error paths from `return -1` to `break` so a failure on one card doesn't abort the whole scan; guard `close(ctlfd)` against double-close after the MIDI fd path.
- Promote `logged_race` to file scope and reset it on each online transition so the driver-not-yet-bound warning fires again after a fast replug cycle.

**`coremidiio.c`**
- Guard reconnect endpoint matching with `g_src_name[0]`/`g_dst_name[0]` checks so unrelated device events don't trigger a spurious reconnect in virtual-port mode (no `-p` flag).
- Zero-initialise `ctx[2]` before `MIDIClientCreate` so an early hotplug notification can't compare garbage endpoint values and trigger a spurious disconnect.

**`oscmix.c`**
- Remove accidental debug `fprintf` left in `setoutputloopback()`.
- Remove two stray debug lines from `oscsendenum()`.

**`oscmix-gtk.sh`**
- Kill any running oscmix whose on-disk binary has been replaced (i.e. `/proc/<pid>/exe` ends with `(deleted)`) before starting the backend, so the freshly-built binary is always used.
- Drop `exec` before `oscmix-gtk` so the shell stays alive and the `EXIT` trap fires when the window is closed, killing the backend.